### PR TITLE
TypeScript 7.0 대비 구버전 옵션 마이그레이션

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,9 +10,8 @@
     "incremental": true,
     "esModuleInterop": true,
     "module": "esnext",
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "jsx": "preserve",
-    "baseUrl": ".",
     "isolatedModules": true,
     "noImplicitAny": true,
     "noImplicitThis": true,
@@ -26,7 +25,7 @@
       }
     ],
     "paths": {
-      "@/*": ["src/*"],
+      "@/*": ["./src/*"],
       "@axios": ["./config/axios.ts"]
     },
     "resolveJsonModule": true


### PR DESCRIPTION
- TypeScript 7.0에서 제거 예정(Deprecated)인 옵션 수정
- moduleResolution을 'node'에서 'bundler'로 변경
- baseUrl 옵션 제거 및 paths 경로 수정 (./ 추가)